### PR TITLE
chore: Update generic dependencies (2 packages)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 fastapi==0.121.2
-joblib==1.5.2
+joblib==1.4.2
 mitreattack-python==5.3.0
 numpy==2.3.5  # This is a common dependency for scikit-learn
 scikit-learn==1.7.2
 stanza==1.11.0
-uvicorn==0.38.0
+uvicorn==0.32.1


### PR DESCRIPTION
# ⬇️ Downgrade Dependencies: joblib and uvicorn

## Summary
This PR downgrades two dependencies to earlier versions. Please review carefully as downgrades may indicate rollback due to compatibility issues or bugs in newer versions.

## Updated Packages

| Package | Previous Version | New Version | Change |
|---------|-----------------|-------------|---------|
| joblib | 1.5.2 | 1.4.2 | ⬇️ Downgrade (minor) |
| uvicorn | 0.38.0 | 0.32.1 | ⬇️ Downgrade (minor) |

## Important Notes

⚠️ **This is a downgrade PR** - These packages are being rolled back to earlier versions.

- **joblib**: Downgrading from 1.5.2 to 1.4.2 (minor version downgrade)
- **uvicorn**: Downgrading from 0.38.0 to 0.32.1 (significant minor version downgrade - 6 minor versions back)

The uvicorn downgrade is particularly significant and may:
- Remove features introduced in versions 0.33.0 - 0.38.0
- Affect ASGI server performance or behavior
- Impact WebSocket handling or HTTP protocol support

## Testing Recommendations

- [ ] Verify all API endpoints respond correctly
- [ ] Test ASGI server startup and shutdown
- [ ] Validate WebSocket connections (if applicable)
- [ ] Run full test suite to ensure no regressions
- [ ] Check for any deprecation warnings in logs
- [ ] Verify background job processing functionality (joblib-dependent code)
- [ ] Performance testing for request handling
- [ ] Review changelogs for both packages to understand what features/fixes are being reverted

## Additional Context

Please provide context on why these downgrades are necessary (e.g., compatibility issues, bugs in newer versions, dependency conflicts).